### PR TITLE
fix LIBDIR install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
 
+project(infamous-plugins)
+
+set(LIBDIR lib CACHE STRING "Specifies the name of the library path")
+
 foreach(plug casynth envfollower hip2b powerup powercut cheapdist stuck ewham duffer)# lushlife)
     add_subdirectory(src/${plug})
 endforeach(plug)

--- a/README
+++ b/README
@@ -9,6 +9,13 @@ To install, fulfill the dependencies (below), then run the commands:
     make
     sudo make install
 
+To install the package under a specific library path, use LIBDIR cmake variabe:
+    mkdir build
+    cd build
+    cmake -DLIBDIR=lib64 ..
+    make
+    sudo make install
+
 Once this is complete you can already start using the plugins in your favorite LV2 host
 
 Dependencies:

--- a/src/casynth/CMakeLists.txt
+++ b/src/casynth/CMakeLists.txt
@@ -1,11 +1,7 @@
 #CMake file for infamous stuck
 
-cmake_minimum_required(VERSION 2.6)
-
 set(PLUGIN "casynth")
-project (${PLUGIN})
 
-set(LV2_INSTALL_DIR lib/lv2/ ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
 #set(CMAKE_C_FLAGS "-Wall -g -std=c99 -msse2 -mfpmath=sse -ffast-math")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -std=c99 -msse2 -mfpmath=sse -ffast-math")
 
@@ -47,9 +43,9 @@ target_link_libraries(${PLUGIN}_ui ${LV2_LIBRARIES} ${NTK_LIBRARIES} ${CAIRO_LIB
 # config install
 install(TARGETS ${PLUGIN} ${PLUGIN}_ui
   LIBRARY
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
 install (FILES manifest.ttl ${PLUGIN}.ttl ${PLUGIN}_presets.ttl
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )

--- a/src/cheapdist/CMakeLists.txt
+++ b/src/cheapdist/CMakeLists.txt
@@ -1,11 +1,7 @@
 #CMake file for infamous stuck
 
-cmake_minimum_required(VERSION 2.6)
-
 set(PLUGIN "cheapdist")
-project (${PLUGIN})
 
-set(LV2_INSTALL_DIR lib/lv2/ ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
 set(CMAKE_C_FLAGS "-Wall -g -msse2 -mfpmath=sse -ffast-math")
 
 # check for our various libraries
@@ -43,9 +39,9 @@ target_link_libraries(${PLUGIN}_ui ${LV2_LIBRARIES} ${NTK_LIBRARIES} ${CAIRO_LIB
 # config install
 install(TARGETS ${PLUGIN} ${PLUGIN}_ui
   LIBRARY
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
 install (FILES manifest.ttl ${PLUGIN}.ttl 
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )

--- a/src/duffer/CMakeLists.txt
+++ b/src/duffer/CMakeLists.txt
@@ -1,11 +1,7 @@
 #CMake file for infamous stuck
 
-cmake_minimum_required(VERSION 2.6)
-
 set(PLUGIN "duffer")
-project (${PLUGIN})
 
-set(LV2_INSTALL_DIR lib/lv2/ ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
 #set(CMAKE_C_FLAGS "-Wall -g -std=c99 -msse2 -mfpmath=sse -ffast-math")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -std=c99 -msse2 -mfpmath=sse -ffast-math")
 
@@ -27,7 +23,6 @@ add_library(${PLUGIN} SHARED
   c_resampler.cpp
   duffing.c
   rk4.c
-
 )
 
 #add_library(${PLUGIN}_ui SHARED
@@ -47,9 +42,9 @@ target_link_libraries(${PLUGIN} ${LV2_LIBRARIES} m zita-resampler)
 # config install
 install(TARGETS ${PLUGIN} #${PLUGIN}_ui
   LIBRARY
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
 install (FILES manifest.ttl ${PLUGIN}.ttl 
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )

--- a/src/envfollower/CMakeLists.txt
+++ b/src/envfollower/CMakeLists.txt
@@ -1,11 +1,7 @@
 #CMake file for infamous stuck
 
-cmake_minimum_required(VERSION 2.6)
-
 set(PLUGIN "envfollower")
-project (${PLUGIN})
 
-set(LV2_INSTALL_DIR lib/lv2/ ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -std=c99 -msse2 -mfpmath=sse -ffast-math")
 
 # check for our various libraries
@@ -48,9 +44,9 @@ target_link_libraries(${PLUGIN}_ui ${LV2_LIBRARIES} ${NTK_LIBRARIES} ${CAIRO_LIB
 # config install
 install(TARGETS ${PLUGIN} ${PLUGIN}_ui
   LIBRARY
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
 install (FILES manifest.ttl ${PLUGIN}.ttl 
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )

--- a/src/ewham/CMakeLists.txt
+++ b/src/ewham/CMakeLists.txt
@@ -1,12 +1,9 @@
 #CMake file for infamous stuck
 
-cmake_minimum_required(VERSION 2.6)
-
 set(PLUGIN "ewham")
-project (${PLUGIN})
+
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/")
 
-set(LV2_INSTALL_DIR lib/lv2/ ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wall -g -msse2 -mfpmath=sse -ffast-math")
 #SET( CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} -lzita-resampler")
 
@@ -50,9 +47,9 @@ target_link_libraries(${PLUGIN} ${LV2_LIBRARIES} ${FFTW_LIBRARIES} m zita-resamp
 # config install
 install(TARGETS ${PLUGIN} # ${PLUGIN}_ui
   LIBRARY
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
 install (FILES manifest.ttl ${PLUGIN}.ttl 
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )

--- a/src/hip2b/CMakeLists.txt
+++ b/src/hip2b/CMakeLists.txt
@@ -1,11 +1,7 @@
 #CMake file for infamous stuck
 
-cmake_minimum_required(VERSION 2.6)
-
 set(PLUGIN "hip2b")
-project (${PLUGIN})
 
-set(LV2_INSTALL_DIR lib/lv2/ ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g -msse2 -mfpmath=sse -ffast-math")
 
 # check for our various libraries
@@ -45,9 +41,9 @@ target_link_libraries(${PLUGIN}_ui ${LV2_LIBRARIES} ${NTK_LIBRARIES} ${CAIRO_LIB
 # config install
 install(TARGETS ${PLUGIN} ${PLUGIN}_ui
   LIBRARY
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
 install (FILES manifest.ttl ${PLUGIN}.ttl 
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )

--- a/src/lushlife/CMakeLists.txt
+++ b/src/lushlife/CMakeLists.txt
@@ -1,12 +1,9 @@
 #CMake file for infamous stuck
 
-cmake_minimum_required(VERSION 2.6)
-
 set(PLUGIN "lushlife")
-project (${PLUGIN})
+
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/")
 
-set(LV2_INSTALL_DIR lib/lv2/ ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
 set(CMAKE_CXX_FLAGS "-Wall -g -msse2 -mfpmath=sse -ffast-math")
 #SET( CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} -lzita-resampler")
 
@@ -54,9 +51,9 @@ target_link_libraries(${PLUGIN} ${LV2_LIBRARIES} ${FFTW_LIBRARIES} m zita-resamp
 # config install
 install(TARGETS ${PLUGIN} # ${PLUGIN}_ui
   LIBRARY
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
 install (FILES manifest.ttl ${PLUGIN}.ttl 
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )

--- a/src/powercut/CMakeLists.txt
+++ b/src/powercut/CMakeLists.txt
@@ -1,11 +1,7 @@
 #CMake file for infamous stuck
 
-cmake_minimum_required(VERSION 2.6)
-
 set(PLUGIN "powercut")
-project (${PLUGIN})
 
-set(LV2_INSTALL_DIR lib/lv2/ ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g -msse2 -mfpmath=sse -ffast-math")
 
 # check for our various libraries
@@ -45,9 +41,9 @@ target_link_libraries(${PLUGIN}_ui ${LV2_LIBRARIES} ${NTK_LIBRARIES} ${CAIRO_LIB
 # config install
 install(TARGETS ${PLUGIN} ${PLUGIN}_ui
   LIBRARY
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
 install (FILES manifest.ttl ${PLUGIN}.ttl 
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )

--- a/src/powerup/CMakeLists.txt
+++ b/src/powerup/CMakeLists.txt
@@ -1,11 +1,7 @@
 #CMake file for infamous stuck
 
-cmake_minimum_required(VERSION 2.6)
-
 set(PLUGIN "powerup")
-project (${PLUGIN})
 
-set(LV2_INSTALL_DIR lib/lv2/ ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g -msse2 -mfpmath=sse -ffast-math")
 
 # check for our various libraries
@@ -45,9 +41,9 @@ target_link_libraries(${PLUGIN}_ui ${LV2_LIBRARIES} ${NTK_LIBRARIES} ${CAIRO_LIB
 # config install
 install(TARGETS ${PLUGIN} ${PLUGIN}_ui
   LIBRARY
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
 install (FILES manifest.ttl ${PLUGIN}.ttl 
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )

--- a/src/stuck/CMakeLists.txt
+++ b/src/stuck/CMakeLists.txt
@@ -1,11 +1,7 @@
 #CMake file for infamous stuck
 
-cmake_minimum_required(VERSION 2.6)
-
 set(PLUGIN "stuck")
-project (${PLUGIN})
 
-set(LV2_INSTALL_DIR lib/lv2/ ) # CACHE PATH "Specifies where the LV2 libraries should be installed")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g -msse2 -mfpmath=sse -ffast-math")
 
 # check for our various libraries
@@ -47,9 +43,9 @@ target_link_libraries(${PLUGIN}_ui ${LV2_LIBRARIES} ${NTK_LIBRARIES} ${CAIRO_LIB
 # config install
 install(TARGETS ${PLUGIN} ${PLUGIN}_ui
   LIBRARY
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
 install (FILES manifest.ttl ${PLUGIN}.ttl 
-  DESTINATION ${LV2_INSTALL_DIR}${PLUGIN}.lv2
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )


### PR DESCRIPTION
Fix the installation under some distribution. Under fedora, we need to install LV2 plugins under /usr/lib64/lv2.
Add a LIBDIR variable in cmake.
Example of use:
mkdir build
cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=/usr -DLIBDIR=lib64 ..
make
sudo make install
