### PR TITLE
Mindi: Update category to Midi plugin

### DIFF
--- a/src/mindi/manifest.ttl
+++ b/src/mindi/manifest.ttl
@@ -3,6 +3,6 @@
 @prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
 
 <http://ssj71.github.io/infamousPlugins/plugs.html#mindi>
-    a lv2:Plugin, lv2:GeneratorPlugin ;
+    a lv2:Plugin, lv2:MIDIPlugin ;
     lv2:binary <mindi.so> ;
     rdfs:seeAlso <mindi.ttl> .


### PR DESCRIPTION
Hi,

Here is a proposal to update the category of your Mindi plugin.

It is difficult to found this plugin grouped by category, cause i think `Generator` is supposed to generate sound, not Midi signal.

Here is the comment page on Mod: https://pedalboards.moddevices.com/plugins/aHR0cDovL3NzajcxLmdpdGh1Yi5pby9pbmZhbW91c1BsdWdpbnMvcGx1Z3MuaHRtbCNtaW5kaQ==

Regards,