### PR TITLE
Fixing build for lv2 >= 1.18.0

### DIFF
--- a/src/casynth/casynth_ui_main.cxx
+++ b/src/casynth/casynth_ui_main.cxx
@@ -10,7 +10,7 @@
 
 #define CASYNTHUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#casynth_ui"
 
-static LV2UI_Handle init_casynthUI(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle init_casynthUI(const struct LV2UI_Descriptor * descriptor,
 		const char * plugin_uri,
 		const char * bundle_path,
 		LV2UI_Write_Function write_function,

--- a/src/cheapdist/cheapdist_ui_main.cxx
+++ b/src/cheapdist/cheapdist_ui_main.cxx
@@ -7,7 +7,7 @@
 
 #define CHEAPDISTUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#cheapdist_ui"
 
-static LV2UI_Handle init_cheapdistUI(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle init_cheapdistUI(const struct LV2UI_Descriptor * descriptor,
 		const char * plugin_uri,
 		const char * bundle_path,
 		LV2UI_Write_Function write_function,

--- a/src/envfollower/envfollower_ui_main.cxx
+++ b/src/envfollower/envfollower_ui_main.cxx
@@ -12,7 +12,7 @@
 #define ENVFOLLOWERUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#envfollower_ui"
 #define ENVFOLLOWERCVUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#envfollowerCV_ui"
 
-static LV2UI_Handle init_envfollowerUI(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle init_envfollowerUI(const struct LV2UI_Descriptor * descriptor,
 		const char * plugin_uri,
 		const char * bundle_path,
 		LV2UI_Write_Function write_function,

--- a/src/hip2b/hip2b_ui_main.cxx
+++ b/src/hip2b/hip2b_ui_main.cxx
@@ -7,7 +7,7 @@
 
 #define HIP2BUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#hip2b_ui"
 
-static LV2UI_Handle init_hip2bUI(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle init_hip2bUI(const struct LV2UI_Descriptor * descriptor,
 		const char * plugin_uri,
 		const char * bundle_path,
 		LV2UI_Write_Function write_function,

--- a/src/lushlife/lushlife_ui_main.cxx
+++ b/src/lushlife/lushlife_ui_main.cxx
@@ -10,7 +10,7 @@
 
 #define LUSHLIFEUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#lushlife_ui"
 
-static LV2UI_Handle init_lushlifeUI(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle init_lushlifeUI(const struct LV2UI_Descriptor * descriptor,
 		const char * plugin_uri,
 		const char * bundle_path,
 		LV2UI_Write_Function write_function,

--- a/src/powercut/powercut_ui_main.cxx
+++ b/src/powercut/powercut_ui_main.cxx
@@ -9,7 +9,7 @@
 
 #define POWERCUTUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#powercut_ui"
 
-static LV2UI_Handle init_powercutUI(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle init_powercutUI(const struct LV2UI_Descriptor * descriptor,
 		const char * plugin_uri,
 		const char * bundle_path,
 		LV2UI_Write_Function write_function,

--- a/src/powerup/powerup_ui_main.cxx
+++ b/src/powerup/powerup_ui_main.cxx
@@ -9,7 +9,7 @@
 
 #define POWERUPUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#powerup_ui"
 
-static LV2UI_Handle init_powerupUI(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle init_powerupUI(const struct LV2UI_Descriptor * descriptor,
 		const char * plugin_uri,
 		const char * bundle_path,
 		LV2UI_Write_Function write_function,

--- a/src/stuck/stuck_ui_main.cxx
+++ b/src/stuck/stuck_ui_main.cxx
@@ -10,7 +10,7 @@
 #define STUCKUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#stuck_ui"
 #define STUCKSTACKERUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#stuckstacker_ui"
 
-static LV2UI_Handle init_stuckUI(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle init_stuckUI(const struct LV2UI_Descriptor * descriptor,
 		const char * plugin_uri,
 		const char * bundle_path,
 		LV2UI_Write_Function write_function,


### PR DESCRIPTION
Replacing all instances of _LV2UI_Descriptor with LV2UI_Descriptor.
This has been a breaking change in lv2 1.18.0.

Closes #38