### PR TITLE
PLUGINS variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project(infamous-plugins)
 
 set(LIBDIR lib CACHE STRING "Specifies the name of the library path")
 
-foreach(plug casynth envfollower hip2b powerup powercut cheapdist stuck ewham lushlife bentdelay mindi octolo)
+set( PLUGINS "casynth;envfollower;hip2b;powerup;powercut;cheapdist;stuck;ewham;lushlife;bentdelay;mindi;octolo" CACHE STRING "List of plugins to build")
+
+foreach( plug ${PLUGINS} )
     add_subdirectory(src/${plug})
 endforeach(plug)
 


### PR DESCRIPTION
I would propose this patch to enable: cmake -DPLUGINS=plugin1;plugin2...
This allows to select a subset of plugins. If not set the variable PLUGINS is defined with a default (complete) set of plugins.

I'm using this like this at : https://github.com/auto3000/meta-pedalpi/blob/master/recipes-lv2/infamousplugins/infamousplugins_git.bb#L16

I come with this (minor) proposal after I reviewed the fork at https://github.com/BlokasLabs/infamousPlugins/ that required similar needs.