### PR TITLE
modgui: add option MOD=ON to install resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8)
 
 project(infamous-plugins)
 
+option(MOD "Install MOD gui resources" OFF)
+
 set(LIBDIR lib CACHE STRING "Specifies the name of the library path")
 
 foreach(plug casynth envfollower hip2b powerup powercut cheapdist stuck ewham lushlife bentdelay mindi octolo)

--- a/README
+++ b/README
@@ -16,6 +16,8 @@ To install the package under a specific library path (i.e. if you are using fedo
     make
     sudo make install
 
+To install the MOD gui resources, use the optional variable '-DMOD=ON' to cmake.
+
 Once this is complete you can already start using the plugins in your favorite LV2 host
 
 There is also an uninstall available:

--- a/src/ewham/CMakeLists.txt
+++ b/src/ewham/CMakeLists.txt
@@ -52,14 +52,14 @@ install(TARGETS ${PLUGIN}
 install (FILES manifest.ttl ${PLUGIN}.ttl
   DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
+if(MOD)
+    install (DIRECTORY modgui/
+      DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2/modgui
+    )
+endif()
 
 if(NOT CAIRO_FOUND OR NOT NTK_FOUND)
     message(WARNING "UI Libraries Missing, no GUI will be installed")
-    if(NOT SUPPORTS_SSE) #hopefully its a mod, so install the modguistuff
-        install (DIRECTORY modgui/
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2/modgui
-        )
-    endif()
 endif() 
 #    find_program(FLTK_FLUID_EXECUTABLE ntk-fluid)
 #    fltk_wrap_ui(${PLUGIN}_ui ${PLUGIN}_ui.fl)

--- a/src/hip2b/CMakeLists.txt
+++ b/src/hip2b/CMakeLists.txt
@@ -48,6 +48,12 @@ install (FILES manifest.ttl ${PLUGIN}.ttl ${PLUGIN}_presets.ttl
   DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
+if(MOD)
+    install (DIRECTORY modgui/
+      DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2/modgui
+    )
+endif()
+
 if(CAIRO_FOUND AND NTK_FOUND)
     find_program(FLTK_FLUID_EXECUTABLE ntk-fluid)
     fltk_wrap_ui(${PLUGIN}_ui ${PLUGIN}_ui.fl)
@@ -68,10 +74,4 @@ if(CAIRO_FOUND AND NTK_FOUND)
 
 else()
     message(WARNING "UI Libraries Missing, no GUI will be installed")
-    if(NOT SUPPORTS_SSE) #hopefully its a mod, so install the modguistuff
-        install (DIRECTORY
-          modgui/
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2/modgui
-        )
-    endif()
 endif()

--- a/src/mindi/CMakeLists.txt
+++ b/src/mindi/CMakeLists.txt
@@ -47,13 +47,15 @@ install (FILES manifest.ttl ${PLUGIN}.ttl
   DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
+if(MOD)
+    message(STATUS "MOD resources are installed")
+    install (DIRECTORY modgui/
+      DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2/modgui
+    )
+endif()
+
 if(NOT CAIRO_FOUND OR NOT NTK_FOUND)
     message(WARNING "UI Libraries Missing, no GUI will be installed")
-    if(NOT SUPPORTS_SSE) #hopefully its a mod, so install the modguistuff
-        install (DIRECTORY modgui/
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2/modgui
-        )
-    endif()
 endif()
 #else()
 #    find_program(FLTK_FLUID_EXECUTABLE ntk-fluid)

--- a/src/powercut/CMakeLists.txt
+++ b/src/powercut/CMakeLists.txt
@@ -48,6 +48,12 @@ install (FILES manifest.ttl ${PLUGIN}.ttl
   DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
+if(MOD)
+    install (DIRECTORY modgui/
+      DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2/modgui
+    )
+endif()
+
 if(CAIRO_FOUND AND NTK_FOUND)
     find_program(FLTK_FLUID_EXECUTABLE ntk-fluid)
     fltk_wrap_ui(${PLUGIN}_ui ${PLUGIN}_ui.fl)
@@ -68,10 +74,4 @@ if(CAIRO_FOUND AND NTK_FOUND)
 
 else()
     message(WARNING "UI Libraries Missing, no GUI will be installed")
-    if(NOT SUPPORTS_SSE) #hopefully its a mod, so install the modguistuff
-        install (DIRECTORY
-          modgui/
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2/modgui
-        )
-    endif()
 endif() 

--- a/src/stuck/CMakeLists.txt
+++ b/src/stuck/CMakeLists.txt
@@ -50,6 +50,23 @@ install (FILES manifest.ttl ${PLUGIN}.ttl
   DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2
 )
 
+if( MOD )
+    install (FILES 
+        modgui/${PLUGIN}.html 
+        modgui/stuckstacker.html 
+        modgui/${PLUGIN}.css
+        modgui/stuckbg.svg
+        modgui/stacker.svg
+        modgui/led-bypassed.png
+        modgui/led-enabled.png
+        modgui/switch-key.png
+        modgui/tabDial64.svg
+        modgui/screenshot-stuck.png
+        modgui/thumbnail-stuck.png
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2/modgui
+    )
+endif()
+
 if(CAIRO_FOUND AND NTK_FOUND)
     find_program(FLTK_FLUID_EXECUTABLE ntk-fluid)
     fltk_wrap_ui(${PLUGIN}_ui ${PLUGIN}_ui.fl)
@@ -70,21 +87,5 @@ if(CAIRO_FOUND AND NTK_FOUND)
 
 else()
     message(WARNING "UI Libraries Missing, no GUI will be installed")
-    if(NOT SUPPORTS_SSE) #hopefully its a mod, so install the modguistuff
-        install (FILES 
-          modgui/${PLUGIN}.html 
-          modgui/stuckstacker.html 
-          modgui/${PLUGIN}.css
-          modgui/stuckbg.svg
-          modgui/stacker.svg
-          modgui/led-bypassed.png
-          modgui/led-enabled.png
-          modgui/switch-key.png
-          modgui/tabDial64.svg
-          modgui/screenshot-stuck.png
-          modgui/thumbnail-stuck.png
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/${LIBDIR}/lv2/${PLUGIN}.lv2/modgui
-        )
-    endif()
 endif()
 


### PR DESCRIPTION
I would propose this patch to enable: cmake -DMOD=ON
This allows to install the modgui. If not set the variable MOD is defined with OFF.

I'm using this like this at : https://github.com/auto3000/meta-pedalpi/blob/master/recipes-lv2/infamousplugins/infamousplugins_git.bb#L16

I come with this (minor) proposal because I need to install modgui on a x86 machine (with SSE flags... consequently this was not possible to install modgui on x86).