### PR TITLE
add parameter REPEATWHENDISABLE

### DIFF
--- a/README
+++ b/README
@@ -238,6 +238,7 @@ this plugin was made for the MOD ecosystem, but may be of some use outside of th
     DATA2 - value for CCs, velocity for notes, ignored for PG
     DELAY - send a message N milliseconds after the plugin is first created
     AUTOFF - automatically send note-off messages when the enable is turned off and in note-on mode (makes mindi a practical one note trigger)
+    REPEATWHENDISABLE - repeats the midi message when the enable is turned off (regardless of AUTOFF setting)
 
 =================================
 13. octolo

--- a/src/mindi/mindi.h
+++ b/src/mindi/mindi.h
@@ -14,7 +14,8 @@ enum mindi_ports
     DATA1,
     DATA2,
     DELAY,
-    AUTOFF
+    AUTOFF,
+    REPEATWHENDISABLE
 };
 
 #endif

--- a/src/mindi/mindi.ttl
+++ b/src/mindi/mindi.ttl
@@ -129,4 +129,15 @@
                 lv2:portProperty lv2:integer ;
                 lv2:portProperty lv2:toggled ;
                 rdfs:comment "This will send a note off when enable is set to 0 when mindi is configured to send note-on messages, only the note configuration set at that time is sent" ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 8 ;
+                lv2:symbol "REPEATWHENDISABLE" ;
+                lv2:name "Repeat Msg When Disable" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 1 ;
+                lv2:portProperty lv2:integer ;
+                lv2:portProperty lv2:toggled ;
+                rdfs:comment "This will repeat the midi message when enable is set to 0 (message would be identical to the initial message, regardless of the Auto Note-Off setting)" ;
         ] .


### PR DESCRIPTION
This parameter will repeat the midi message when enable is set to 0. The message would be identical to the initial message, (regardless of the Auto Note-Off setting).

The reason I've added this ability is so that the Mod Duo's Footswitch can send a message every time the user presses a button, instead of being limited to sending a message only every other time the user presses that button.

(The main motivation for me to do this is so I can use the Mod Duo Footswitch as a control surface for Ardour's play, stop, & record buttons)