### PR TITLE
Mindi momentary value

### DIFF
--- a/README
+++ b/README
@@ -232,12 +232,13 @@ This is a simulated double tracking plugin capable of everything from a thin bea
 this plugin was made for the MOD ecosystem, but may be of some use outside of that application. It is a mini MIDI message maker. Simply compose a midi message and enable it and it will send out the message. It also sends a message whenever you change values so you can use it to control midi CCs for example. It can compose and send sysex type messages, but not practical ones.
 
 
-    MSGTYPE - note, pressure, CC, bend you name it we'll make it
+    MSGTYPE - note on/off, CC, PG, poly pressure, channel pressure, pitchbend
     CHAN - channel 0-15
-    DATA1 - note, CC, or PG number
-    DATA2 - value for CCs, velocity for notes, ignored for PG
+    NOTECCPG - note, CC, or PG number
+    VALUE - value for CCs, pressure, pitchbend, and velocity for notes, ignored for PG
     DELAY - send a message N milliseconds after the plugin is first created
     AUTOFF - automatically send note-off messages when the enable is turned off and in note-on mode (makes mindi a practical one note trigger)
+    MOMENT - button to send a midi message with MOMENTARYVALUE when pressed and a second message with VALUE when released (which will be a note-off message when AUTOFF is used to turn off note-on messages) 
 
 =================================
 13. octolo

--- a/src/mindi/mindi.h
+++ b/src/mindi/mindi.h
@@ -14,7 +14,9 @@ enum mindi_ports
     DATA1,
     DATA2,
     DELAY,
-    AUTOFF
+    AUTOFF,
+    MOMENT,
+    DATA2B
 };
 
 #endif

--- a/src/mindi/mindi.h
+++ b/src/mindi/mindi.h
@@ -11,12 +11,12 @@ enum mindi_ports
     ENABLE,
     MSGTYPE,
     CHAN,
-    DATA1,
-    DATA2,
+    NOTECCPG,
+    VALUE,
     DELAY,
     AUTOFF,
     MOMENT,
-    DATA2B
+    MOMENTARYVALUE
 };
 
 #endif

--- a/src/mindi/mindi.ttl
+++ b/src/mindi/mindi.ttl
@@ -129,4 +129,26 @@
                 lv2:portProperty lv2:integer ;
                 lv2:portProperty lv2:toggled ;
                 rdfs:comment "This will send a note off when enable is set to 0 when mindi is configured to send note-on messages, only the note configuration set at that time is sent" ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 8 ;
+                lv2:symbol "MOMENT" ;
+                lv2:name "Momentary Button" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 1 ;
+                lv2:portProperty lv2:integer ;
+                lv2:portProperty lv2:toggled ;
+                lv2:portProperty pprops:trigger ;
+                rdfs:comment "This control will send one midi message when pressed, and another when released" ;
+        ], [
+                a lv2:InputPort, lv2:ControlPort ;
+                lv2:index 9 ;
+                lv2:symbol "DATA2B" ;
+                lv2:name "Momentary Pressed Value" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 127 ;
+                lv2:portProperty lv2:integer ;
+                rdfs:comment "data to send when momentary button is pressed, for notes set this to the desired velocity and Value to 0" ;
         ] .

--- a/src/mindi/mindi.ttl
+++ b/src/mindi/mindi.ttl
@@ -39,7 +39,7 @@
             modgui:label "mindi" ;
         ] ;
         lv2:minorVersion 0 ;
-        lv2:microVersion 3 ;
+        lv2:microVersion 4 ;
         rdfs:comment "This is a simple midi message generator that sends a message when you change its message value. It usually requires the host automating it to really be useful." ;
         lv2:requiredFeature <http://lv2plug.in/ns/ext/urid#map> ;
         lv2:optionalFeature lv2:hardRTCapable ;
@@ -93,8 +93,8 @@
         ], [
                 a lv2:InputPort, lv2:ControlPort ;
                 lv2:index 4 ;
-                lv2:symbol "DATA1" ;
-                lv2:name "Note/CC/PG Number" ;
+                lv2:symbol "NOTECCPG" ;
+                lv2:name "Note/CC/PG" ;
                 lv2:default 0 ;
                 lv2:minimum 0 ;
                 lv2:maximum 127 ;
@@ -102,7 +102,7 @@
         ], [
                 a lv2:InputPort, lv2:ControlPort ;
                 lv2:index 5 ;
-                lv2:symbol "DATA2" ;
+                lv2:symbol "VALUE" ;
                 lv2:name "Value" ;
                 lv2:default 0 ;
                 lv2:minimum 0 ;
@@ -112,7 +112,7 @@
                 a lv2:InputPort, lv2:ControlPort ;
                 lv2:index 6 ;
                 lv2:symbol "DELAY" ;
-                lv2:name "1st Msg Repeat Delay Time" ;
+                lv2:name "Msg Repeat Delay" ;
                 lv2:default 0.0 ;
                 lv2:minimum 0.0 ;
                 lv2:maximum 2000.0 ;
@@ -144,8 +144,8 @@
         ], [
                 a lv2:InputPort, lv2:ControlPort ;
                 lv2:index 9 ;
-                lv2:symbol "DATA2B" ;
-                lv2:name "Momentary Pressed Value" ;
+                lv2:symbol "MOMENTARYVALUE" ;
+                lv2:name "Momentary Value" ;
                 lv2:default 0 ;
                 lv2:minimum 0 ;
                 lv2:maximum 127 ;
@@ -160,9 +160,9 @@
 	lv2:port
         [ lv2:symbol "AUTOFF" ; pset:value 0.0 ] ,
         [ lv2:symbol "CHAN" ; pset:value 0.0 ] ,
-        [ lv2:symbol "DATA1" ; pset:value 3.0 ] ,
-        [ lv2:symbol "DATA2" ; pset:value 0.0 ] ,
-        [ lv2:symbol "DATA2B" ; pset:value 125.0 ] ,
+        [ lv2:symbol "NOTECCPG" ; pset:value 3.0 ] ,
+        [ lv2:symbol "VALUE" ; pset:value 0.0 ] ,
+        [ lv2:symbol "MOMENTARYVALUE" ; pset:value 125.0 ] ,
         [ lv2:symbol "DELAY" ; pset:value 0.0 ] ,
         [ lv2:symbol "ENABLE" ; pset:value 1.0 ] ,
         [ lv2:symbol "MOMENT" ; pset:value 0.0 ] ,
@@ -175,9 +175,9 @@
 	lv2:port
         [ lv2:symbol "AUTOFF" ; pset:value 0.0 ] ,
         [ lv2:symbol "CHAN" ; pset:value 9.0 ] ,
-        [ lv2:symbol "DATA1" ; pset:value 38.0 ] ,
-        [ lv2:symbol "DATA2" ; pset:value 0.0 ] ,
-        [ lv2:symbol "DATA2B" ; pset:value 125.0 ] ,
+        [ lv2:symbol "NOTECCPG" ; pset:value 38.0 ] ,
+        [ lv2:symbol "VALUE" ; pset:value 0.0 ] ,
+        [ lv2:symbol "MOMENTARYVALUE" ; pset:value 125.0 ] ,
         [ lv2:symbol "DELAY" ; pset:value 0.0 ] ,
         [ lv2:symbol "ENABLE" ; pset:value 1.0 ] ,
         [ lv2:symbol "MOMENT" ; pset:value 0.0 ] ,
@@ -190,9 +190,9 @@
 	lv2:port
         [ lv2:symbol "AUTOFF" ; pset:value 0.0 ] ,
         [ lv2:symbol "CHAN" ; pset:value 0.0 ] ,
-        [ lv2:symbol "DATA1" ; pset:value 38.0 ] ,
-        [ lv2:symbol "DATA2" ; pset:value 20.0 ] ,
-        [ lv2:symbol "DATA2B" ; pset:value 100.0 ] ,
+        [ lv2:symbol "NOTECCPG" ; pset:value 38.0 ] ,
+        [ lv2:symbol "VALUE" ; pset:value 20.0 ] ,
+        [ lv2:symbol "MOMENTARYVALUE" ; pset:value 100.0 ] ,
         [ lv2:symbol "DELAY" ; pset:value 0.0 ] ,
         [ lv2:symbol "ENABLE" ; pset:value 1.0 ] ,
         [ lv2:symbol "MOMENT" ; pset:value 0.0 ] ,

--- a/src/mindi/mindi.ttl
+++ b/src/mindi/mindi.ttl
@@ -39,7 +39,7 @@
             modgui:label "mindi" ;
         ] ;
         lv2:minorVersion 0 ;
-        lv2:microVersion 1 ;
+        lv2:microVersion 3 ;
         rdfs:comment "This is a simple midi message generator that sends a message when you change its message value. It usually requires the host automating it to really be useful." ;
         lv2:requiredFeature <http://lv2plug.in/ns/ext/urid#map> ;
         lv2:optionalFeature lv2:hardRTCapable ;
@@ -152,3 +152,48 @@
                 lv2:portProperty lv2:integer ;
                 rdfs:comment "data to send when momentary button is pressed, for notes set this to the desired velocity and Value to 0" ;
         ] .
+
+<http://ssj71.github.io/infamousPlugins/plugs.html#mindi:preset:00Program>
+    a pset:Preset ;
+    lv2:appliesTo <http://ssj71.github.io/infamousPlugins/plugs.html#mindi> ;
+    rdfs:label "00 Program" ;
+	lv2:port
+        [ lv2:symbol "AUTOFF" ; pset:value 0.0 ] ,
+        [ lv2:symbol "CHAN" ; pset:value 0.0 ] ,
+        [ lv2:symbol "DATA1" ; pset:value 3.0 ] ,
+        [ lv2:symbol "DATA2" ; pset:value 0.0 ] ,
+        [ lv2:symbol "DATA2B" ; pset:value 125.0 ] ,
+        [ lv2:symbol "DELAY" ; pset:value 0.0 ] ,
+        [ lv2:symbol "ENABLE" ; pset:value 1.0 ] ,
+        [ lv2:symbol "MOMENT" ; pset:value 0.0 ] ,
+        [ lv2:symbol "MSGTYPE" ; pset:value 12.0 ] .
+
+<http://ssj71.github.io/infamousPlugins/plugs.html#mindi:preset:01Snare>
+    a pset:Preset ;
+    lv2:appliesTo <http://ssj71.github.io/infamousPlugins/plugs.html#mindi> ;
+    rdfs:label "01 Snare" ;
+	lv2:port
+        [ lv2:symbol "AUTOFF" ; pset:value 0.0 ] ,
+        [ lv2:symbol "CHAN" ; pset:value 9.0 ] ,
+        [ lv2:symbol "DATA1" ; pset:value 38.0 ] ,
+        [ lv2:symbol "DATA2" ; pset:value 0.0 ] ,
+        [ lv2:symbol "DATA2B" ; pset:value 125.0 ] ,
+        [ lv2:symbol "DELAY" ; pset:value 0.0 ] ,
+        [ lv2:symbol "ENABLE" ; pset:value 1.0 ] ,
+        [ lv2:symbol "MOMENT" ; pset:value 0.0 ] ,
+        [ lv2:symbol "MSGTYPE" ; pset:value 9.0 ] .
+
+<http://ssj71.github.io/infamousPlugins/plugs.html#mindi:preset:02CCboost>
+    a pset:Preset ;
+    lv2:appliesTo <http://ssj71.github.io/infamousPlugins/plugs.html#mindi> ;
+    rdfs:label "02 CC Boost" ;
+	lv2:port
+        [ lv2:symbol "AUTOFF" ; pset:value 0.0 ] ,
+        [ lv2:symbol "CHAN" ; pset:value 0.0 ] ,
+        [ lv2:symbol "DATA1" ; pset:value 38.0 ] ,
+        [ lv2:symbol "DATA2" ; pset:value 20.0 ] ,
+        [ lv2:symbol "DATA2B" ; pset:value 100.0 ] ,
+        [ lv2:symbol "DELAY" ; pset:value 0.0 ] ,
+        [ lv2:symbol "ENABLE" ; pset:value 1.0 ] ,
+        [ lv2:symbol "MOMENT" ; pset:value 0.0 ] ,
+        [ lv2:symbol "MSGTYPE" ; pset:value 11.0 ] .

--- a/src/mindi/modgui/mindi.html
+++ b/src/mindi/modgui/mindi.html
@@ -54,12 +54,12 @@
 
     <div class="mod-control-group top clearfix">
         <div class="mod-knob">
-            <span class="mod-knob-title">Note/CC/PG Number</span>
-            <div class="mod-knob-n128-image" mod-role="input-control-port" mod-port-symbol="DATA1"></div>
+            <span class="mod-knob-title">Note/CC/PG</span>
+            <div class="mod-knob-n128-image" mod-role="input-control-port" mod-port-symbol="NOTECCPG"></div>
         </div>
         <div class="mod-knob">
             <span class="mod-knob-title">Value</span>
-            <div class="mod-knob-n128-image" mod-role="input-control-port" mod-port-symbol="DATA2"></div>
+            <div class="mod-knob-n128-image" mod-role="input-control-port" mod-port-symbol="VALUE"></div>
         </div>
     </div>
 


### PR DESCRIPTION
1. Channel pressure/aftertouch (msgtype 13) now uses the UI's "Value" parameter for value, not the UI's "Note/CC/PG Number" parameter. This makes the behavior consistent with the UI and also consistent with the midi specs https://www.midi.org/specifications-old/item/table-1-summary-of-midi-message which refers to the Channel Pressure message's pressure value as "vvvvvvv".  I've renamed DATA1, DATA2, DATA2B in the .c and .h files to NOTECCPG, VALUE, MOMENTARYVALUE so they are consistent with the UI expressed in the .ttl file, and to simplify the code for how Channel Pressure messages will use VALUE.

2. If AUTOFF is enabled and a note has been sent, a note-off event is sent with VALUE when the momentary button is released.

3. Updated README with momentary behavior.

4. Shortened "Note/CC/PG Number" and "1st Msg Repeat Delay Time" in the .ttl to fit within the 16 character limit of ModDuo's GUI.