### PR TITLE
Fix compiling rule.c

### DIFF
--- a/src/rule.c
+++ b/src/rule.c
@@ -43,7 +43,7 @@ void useage()
     return;
 }
 
-int main(int argc, int8_t **argv)
+int main(int argc, char **argv)
 {
     uint8_t rule=0xD0;//0x7c;
     uint8_t t;


### PR DESCRIPTION
On mac+clang I got

```
[ 39%] Building C object src/cheapdist/CMakeFiles/cheapdist.dir/cheapdist.c.o                                                                                                                                                               
cd /tmp/infamousplugins-20210310-76653-ndn0r6/infamousPlugins-0.3.0/src/cheapdist && /usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang -Dcheapdist_EXPORTS -I/usr/local/Cellar/lv2/1.18.2/include -I/tmp/infamousplugins-20210310-7
6653-ndn0r6/infamousPlugins-0.3.0/src/cheapdist/../ffffltk -I/tmp/infamousplugins-20210310-76653-ndn0r6/infamousPlugins-0.3.0/src/cheapdist/../draw -I/tmp/infamousplugins-20210310-76653-ndn0r6/infamousPlugins-0.3.0/src/cheapdist/. -Wall
 -g -Og -msse2 -mfpmath=sse -ffast-math -DNDEBUG -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -fPIC -o CMakeFiles/cheapdist.dir/cheapdist.c.o -c /tmp/infamousplugins-20210310-76653-ndn0r6/infamousPlugins-0.3.0/src/
cheapdist/cheapdist.c                                                                                                                                                                                                                       
/tmp/infamousplugins-20210310-76653-ndn0r6/infamousPlugins-0.3.0/src/rule.c:46:5: error: second parameter of 'main' (argument array) must be of type 'char **'                                                                              
```