### PR TITLE
Fix build with glibc 2.36

### DIFF
--- a/src/casynth/casynth_ui_main.cxx
+++ b/src/casynth/casynth_ui_main.cxx
@@ -7,6 +7,7 @@
 
 #include "casynth_ui.h"
 #include "lv2/lv2plug.in/ns/extensions/ui/ui.h"
+#include <ctime>
 
 #define CASYNTHUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#casynth_ui"
 

--- a/src/lushlife/lushlife_ui_main.cxx
+++ b/src/lushlife/lushlife_ui_main.cxx
@@ -7,6 +7,7 @@
 
 #include "lushlife_ui.h"
 #include "lv2/lv2plug.in/ns/extensions/ui/ui.h"
+#include <ctime>
 
 #define LUSHLIFEUI_URI "http://ssj71.github.io/infamousPlugins/plugs.html#lushlife_ui"
 


### PR DESCRIPTION
| src/lushlife/lushlife_ui_main.cxx:47:27: error: 'time' was not declared in this scope
|    47 |     srand ((unsigned int) time (NULL));
|       |                           ^~~~
| src/lushlife/lushlife_ui_main.cxx:9:1: note: 'time' is defined in header '<ctime>'; did you forget to '#include <ctime>'?

| src/casynth/casynth_ui_main.cxx:47:27: error: 'time' was not declared in this scope
|    47 |     srand ((unsigned int) time (NULL));
|       |                           ^~~~
| src/casynth/casynth_ui_main.cxx:9:1: note: 'time' is defined in header '<ctime>'; did you forget to '#include <ctime>'?

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>